### PR TITLE
Fix dependency list of useEffect

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,7 +102,7 @@ export default ({ type, config = {}, options = {}, history, widgetKey = randomKe
         shouldRender = false
       }
     }
-  }, [container]);
+  }, [container, config, history, options, type, widgetKey]);
 
   return [container, ready, hasError];
 }


### PR DESCRIPTION
Right now the useEffect is not run in all conditions. Example:

1. Go to https://se.tretorn.com/barn/accessoarer/vantar
2. Click any mitten
3. Click "Accessoarer" in the breadcrumbs

This PR solves the issue by adding all the fields that should be there to the dependencies.